### PR TITLE
Use readlink to canonicalize path to script

### DIFF
--- a/copyright-year-updater.sh
+++ b/copyright-year-updater.sh
@@ -2,7 +2,7 @@
 #====================================================================
 # copyright-year-updater.sh
 #
-# Copyright 2015-2017 Fwolf <fwolf.aide+bin.public@gmail.com>
+# Copyright 2015-2017, 2020 Fwolf <fwolf.aide+bin.public@gmail.com>
 # All rights reserved.
 #
 # Distributed under the MIT License.
@@ -17,8 +17,7 @@ VERSION=0.2.4
 
 self="$0"
 if [ -L "$self" ]; then
-    self=$(readlink "$self")
-    self=$(realpath "$self")
+    self=$(readlink -f "$self" || realpath "$(readlink "$self")")
 fi
 P2R=${self%/*}/
 


### PR DESCRIPTION
readlink without `-f` will return the relative value of the symlink and
realpath will fail for values such as `../scm/repo/script.sh` when this
is in `~/bin` and the script is called via the path. readlink will
properly canonicalize the path when `-f` is specified, therefore just
use it.